### PR TITLE
Include array fields in update mask on merge writes

### DIFF
--- a/src/firestore/serializer.ts
+++ b/src/firestore/serializer.ts
@@ -9,7 +9,11 @@ export function encode(map: DocumentData, collector?: UpdateCollector): api.MapV
   Object.entries(map).forEach(([key, value]) => {
     collector?.enterField(key);
     if (value !== undefined) fields[key] = encodeValue(value, collector);
-    const shouldAddMask = !fields[key] || !(fields[key].arrayValue || fields[key].mapValue);
+    // Maps contribute dotted leaf paths via recursion, so adding the map's
+    // own path would cause merge to overwrite sibling fields. Arrays must
+    // add their own path: Firestore fieldPaths can't address array elements,
+    // so arrays are always replaced whole at the parent path.
+    const shouldAddMask = !fields[key] || !fields[key].mapValue;
     collector?.leaveField(shouldAddMask);
   });
   return fields;
@@ -32,7 +36,11 @@ export function encodeValue(value: any, collector?: UpdateCollector) {
   if (value && value.buffer instanceof ArrayBuffer) return { bytesValue: bytesToBase64(value) };
   if (typeof value === 'object' && 'latitude' in value && 'longitude' in value && Object.keys(value).length === 2)
     return { geoPointValue: value };
-  if (Array.isArray(value)) return { arrayValue: { values: value.map(v => encodeValue(v, collector)) } };
+  // Don't pass the collector into array elements. Firestore fieldPaths
+  // cannot address elements by index, so any inner paths the elements
+  // registered (e.g. "books.id") would be invalid. Arrays are replaced
+  // whole at the parent field path.
+  if (Array.isArray(value)) return { arrayValue: { values: value.map(v => encodeValue(v)) } };
   if (typeof value === 'object') return { mapValue: { fields: encode(value, collector) } };
   throw new Error(`Unsupported value type: ${typeof value}`);
 }


### PR DESCRIPTION
## Summary

- `set(data, { merge: true })` was silently dropping top-level arrays because `encode()` didn't add `arrayValue` fields to the `updateMask`. Firestore `update` requests write only what's in `updateMask`, so the array was sent in the payload but discarded server-side.
- Recursing into array elements with the collector also produced phantom paths like `books.id`, which can't resolve to anything because Firestore `fieldPath`s can't address array elements by index.
- Fix: add arrays to the mask at their own path, and don't pass the collector into array-element encoding. Maps keep their existing recursive leaf-path behavior so merge preserves siblings.

## Impact

Found while investigating why the Dabble v2.5→v3 migration wrote `_ops/books` correctly but left the `books` field missing from the project meta state doc. Repro was a `set({ books: [...], modifiedAt: "..." }, { merge: true })` — `modifiedAt` (scalar) landed, `books` (array) didn't.

Any caller using `set(..., { merge: true })` with top-level arrays was affected. Full-overwrite `set()` (no merge) and `update()` paths are unchanged.

## Behavior before/after

`encode({ books: [{ id: 'QToL', title: '', pattern: 9 }], modifiedAt: '...' })` mask:
- Before: `["books.id", "books.title", "books.pattern", "modifiedAt"]` (books path missing, phantom leaf paths)
- After: `["books", "modifiedAt"]`

`encode({ goals: { abc: { end: 50000, targetId: 'QToL' } } })` mask (unchanged):
- `["goals.abc.end", "goals.abc.targetId"]`

## Test plan

- [x] `tsc` builds cleanly
- [x] Manually verified encode output for: arrays + scalars, nested maps, empty map, empty array, mixed (see PR description)
- [ ] Publish new version, bump `workers-firebase` in `dabble-migrations`, re-run migration for a project that was missing `books` and confirm the field lands in the state doc