### PR TITLE
Surface per-write failures in WriteBatch.commit()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workers-firebase",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "scripts": {
     "start": "tsc --watch",

--- a/src/firestore/write-batch.ts
+++ b/src/firestore/write-batch.ts
@@ -2,9 +2,9 @@ import { UpdateCollector } from './field-value';
 import { Firestore } from './firestore';
 import { DocumentReference } from './reference';
 import { encode } from './serializer';
+import { BatchWriteError, type BatchWriteFailure } from '../status-error';
 import { updateSymbol, writesSymbol } from './symbols';
 import type { DocumentData, PartialWithFieldValue, SetOptions, UpdateData, WithFieldValue, api } from './types';
-
 
 export class WriteBatch {
   private [writesSymbol]: api.Write[] = [];
@@ -32,19 +32,38 @@ export class WriteBatch {
   delete<T = DocumentData>(ref: DocumentReference<T>, precondition?: api.Precondition): this {
     this[writesSymbol].push({
       delete: ref.qualifiedPath,
-      currentDocument: precondition
+      currentDocument: precondition,
     });
     return this;
   }
 
   async commit(): Promise<Date[]> {
     Object.freeze(this[writesSymbol]);
-    if (this.firestore[writesSymbol]) { // transaction
+    if (this.firestore[writesSymbol]) {
+      // transaction
       this.firestore[writesSymbol].push(...this[writesSymbol]);
       return;
     }
-    const response = await this.firestore.request<api.BatchWriteResponse>('POST', ':batchWrite', { writes: this[writesSymbol] });
-    return response.writeResults.map(result => result.updateTime && new Date(result.updateTime) || undefined);
+    const response = await this.firestore.request<api.BatchWriteResponse>('POST', ':batchWrite', {
+      writes: this[writesSymbol],
+    });
+    // :batchWrite is non-atomic: each write has an independent status.
+    // Surface per-write failures so callers can retry just the failed ones
+    // instead of silently losing writes under load (hot partitions, rate
+    // limits, etc.).
+    const failures: BatchWriteFailure[] = [];
+    if (response.status) {
+      for (let i = 0; i < response.status.length; i++) {
+        const s = response.status[i];
+        if (s && s.code !== 0 && s.code != null) {
+          failures.push({ index: i, code: s.code, message: s.message ?? '' });
+        }
+      }
+    }
+    if (failures.length > 0) {
+      throw new BatchWriteError(failures);
+    }
+    return response.writeResults.map(result => (result.updateTime && new Date(result.updateTime)) || undefined);
   }
 
   [updateSymbol]<T = DocumentData>(ref: DocumentReference<T>, data: any, type: UpdateType): this {
@@ -73,5 +92,7 @@ export class WriteBatch {
 }
 
 enum UpdateType {
-  create, set, update,
+  create,
+  set,
+  update,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,6 @@ export * from './auth/auth';
 export * from './auth/types';
 export * from './firestore/field-value';
 export * from './firestore';
+export * from './status-error';
 export * from './storage';
 export * from './types';

--- a/src/status-error.ts
+++ b/src/status-error.ts
@@ -1,7 +1,35 @@
-
 export class StatusError extends Error {
-
-  constructor(public code: number, message: string) {
+  constructor(
+    public code: number,
+    message: string
+  ) {
     super(message);
+  }
+}
+
+export interface BatchWriteFailure {
+  index: number;
+  code: number;
+  message: string;
+}
+
+/**
+ * Thrown by `WriteBatch.commit()` when one or more writes in a `:batchWrite`
+ * request failed. Firestore's `:batchWrite` endpoint is non-atomic, so writes
+ * succeed or fail independently. This surfaces the per-write failures so
+ * callers can retry just the failed ones (or fail the whole operation).
+ *
+ * `code` mirrors `failures[0].code` so callers that inspect a single
+ * `err.code` (e.g. to detect `ALREADY_EXISTS` / 6) still work for the common
+ * single-write-batch case.
+ */
+export class BatchWriteError extends StatusError {
+  constructor(public failures: BatchWriteFailure[]) {
+    const first = failures[0];
+    const summary =
+      failures.length === 1
+        ? `batchWrite failed: ${first.message} (code ${first.code})`
+        : `batchWrite failed: ${failures.length} of N writes failed; first: ${first.message} (code ${first.code})`;
+    super(first.code, summary);
   }
 }


### PR DESCRIPTION
## Summary
- `:batchWrite` is non-atomic — each write has an independent status. The old `commit()` only read `writeResults[].updateTime` and ignored `status[]`, so partial failures (hot partitions, `RESOURCE_EXHAUSTED`, `DEADLINE_EXCEEDED`, etc.) silently lost writes while returning success.
- Now inspects `status[]` and throws a new `BatchWriteError` with `failures: [{ index, code, message }]` when any write failed. Callers can retry just the failed indices.
- `BatchWriteError extends StatusError` and sets `code` to `failures[0].code`, so existing single-write `err.code` checks (e.g. pup's `ALREADY_EXISTS` / rev-conflict detection) keep working.

## Context
We hit this on a production-sized migration run: `_changes` docs were missing from v3 Firestore with no error logged. Versions written in the same code path (different endpoint) succeeded, so projects ended up with versions but no/partial change history. This fix surfaces the failures so the migration can retry the lost writes.

## Test plan
- [ ] Manual: trigger a batch that intentionally includes a write that will fail (e.g. a `create` against an existing doc) and verify `BatchWriteError` is thrown with the expected `failures[]`.
- [ ] Manual: verify `err.code === 6` (`ALREADY_EXISTS`) still works for a single-failure batch (pup rev-conflict path).
- [ ] Run the dabble-migrations smoke test against the published `0.2.13` to verify no regressions on fully-successful batches.