### PR TITLE
Enable strict TypeScript, add typecheck/format scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workers-firebase",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "workers-firebase",
-      "version": "0.2.13",
+      "version": "0.3.0",
       "dependencies": {
         "@tsndr/cloudflare-worker-jwt": "^3.2.0",
         "crypto-id": "^0.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "workers-firebase",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "workers-firebase",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@tsndr/cloudflare-worker-jwt": "^3.2.0",
         "crypto-id": "^0.3.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251128.0",
+        "prettier": "^3.8.3",
         "typescript": "^5.9.3"
       }
     },
@@ -34,6 +35,22 @@
       "resolved": "https://registry.npmjs.org/crypto-id/-/crypto-id-0.3.1.tgz",
       "integrity": "sha512-1wAtI9IKZHKXqMV/SNHgLaq0HmS7Jvn946L7qogyahykl+9uNbYT4ZYTT1mz5SJ9+bTRu0ybG7N+67KrEuj0Fg==",
       "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -66,6 +83,12 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/crypto-id/-/crypto-id-0.3.1.tgz",
       "integrity": "sha512-1wAtI9IKZHKXqMV/SNHgLaq0HmS7Jvn946L7qogyahykl+9uNbYT4ZYTT1mz5SJ9+bTRu0ybG7N+67KrEuj0Fg=="
+    },
+    "prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true
     },
     "typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "start": "tsc --watch",
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
     "prepublishOnly": "npm run build"
   },
   "main": "dist/index.js",
@@ -15,6 +18,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251128.0",
+    "prettier": "^3.8.3",
     "typescript": "^5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workers-firebase",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "start": "tsc --watch",

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,11 +3,11 @@ import { Auth } from './auth/auth';
 import { Firestore } from './firestore';
 import { Storage } from './storage';
 
-
 export class App {
-
-  constructor(readonly settings: Settings | ServiceAccountUnderscored, readonly apiKey: string) {
-  }
+  constructor(
+    readonly settings: Settings | ServiceAccountUnderscored,
+    readonly apiKey: string
+  ) {}
 
   firestore() {
     return new Firestore(this.settings, this.apiKey);

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -17,7 +17,7 @@ const returnSecureToken = true; // used for adding boolean in requests
 const uidLength = 28;
 const oauthScope = 'https://www.googleapis.com/auth/identitytoolkit';
 const importAlgorithm = { name: 'RSASSA-PKCS1-v1_5', hash: { name: 'SHA-256' } };
-const textToBytes = (s: string) => new Uint8Array(Array.prototype.map.call(s, (c: string) => c.charCodeAt(0)));
+const textToBytes = (s: string) => Uint8Array.from(s, c => c.charCodeAt(0));
 const base64ToBytes = (s: string) => textToBytes(atob(s.replace(/-/g, '+').replace(/_/g, '/').replace(/\s/g, '')));
 
 export type GetUsersOptions = {
@@ -26,17 +26,20 @@ export type GetUsersOptions = {
 };
 
 export class Auth extends FirebaseService {
-  getToken: (claims?: object) => Promise<string>;
-
   constructor(settings: Settings | ServiceAccountUnderscored, apiKey: string) {
     super('auth', 'https://identitytoolkit.googleapis.com/v1', settings, apiKey);
   }
 
   async setCustomUserClaims(uid: string, claims: Record<string, any>) {
-    await this.request('POST', 'accounts:update', {
-      customAttributes: JSON.stringify(claims),
-      localId: uid,
-    }, oauthScope);
+    await this.request(
+      'POST',
+      'accounts:update',
+      {
+        customAttributes: JSON.stringify(claims),
+        localId: uid,
+      },
+      oauthScope
+    );
   }
 
   async verify(token: string) {
@@ -116,7 +119,7 @@ export class Auth extends FirebaseService {
     const tokens = convertSignInResponse(result);
 
     const user = await this.getUser(tokens.idToken);
-    user.name = name;
+    if (user) user.name = name;
     return { user, tokens };
   }
 
@@ -148,7 +151,8 @@ export class Auth extends FirebaseService {
     // may not be returned in the same order, we will sort it
     const map = new Map<string, User>();
     (response.users || []).forEach((data: any) => map.set(uids ? data.localId : data.email, convertUserData(data)));
-    return (uids || emails).map(lookup => map.get(lookup) || null);
+    const lookups = uids || emails || [];
+    return lookups.map(lookup => map.get(lookup) || null);
   }
 
   async updateUser(idTokenOrUID: string, updates: any) {
@@ -304,17 +308,18 @@ function convertSignInResponse(response: SignInFirebaseResponse): Tokens {
   return { idToken, refreshToken };
 }
 
-let publicKeys: Record<string, JsonWebKeyWithKid>;
+let publicKeys: Record<string, JsonWebKeyWithKid> | undefined;
 async function getPublicKey(kid: string) {
   if (!publicKeys) {
     // Found this resource here https://stackoverflow.com/a/71988314/835542 since the documented one provides x509 certs, not directly useful
     const response = await fetch(
       'https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com'
     );
-    const age = parseInt(response.headers.get('Cache-Control').replace(/^.*max-age=(\d+).*$/, '$1'));
+    const cacheControl = response.headers.get('Cache-Control') || '';
+    const age = parseInt(cacheControl.replace(/^.*max-age=(\d+).*$/, '$1'));
     setTimeout(() => (publicKeys = undefined), age * 1000);
-    publicKeys = ((await response.json()) as GoogleKeysResponse).keys.reduce(
-      (map, key) => (map[key.kid] = key) && map,
+    publicKeys = ((await response.json()) as GoogleKeysResponse).keys.reduce<Record<string, JsonWebKeyWithKid>>(
+      (map, key) => ((map[key.kid] = key), map),
       {}
     );
   }

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -97,7 +97,7 @@ export interface Tokens {
 }
 
 export interface SignInResponse {
-  user: User;
+  user: User | null;
   tokens: Tokens;
   isNewUser?: boolean;
 }
@@ -110,7 +110,7 @@ export interface RequestCode {
 
 export interface User {
   uid: string;
-  name: string;
+  name?: string;
   email: string;
   emailVerified: boolean;
   photoUrl: string;

--- a/src/firestore/document.ts
+++ b/src/firestore/document.ts
@@ -3,41 +3,52 @@ import { decode, decodeValue } from './serializer';
 import { docSymbol, readTimeSymbol } from './symbols';
 import { api, DocumentData } from './types';
 
-
 export class DocumentSnapshot<T = DocumentData> {
+  private [docSymbol]: api.Document;
+  private [readTimeSymbol]: string | undefined;
 
-  constructor(readonly ref: DocumentReference<T>, doc: api.Document = { name: ref.qualifiedPath, fields: null }, readTime?: string) {
+  constructor(
+    readonly ref: DocumentReference<T>,
+    doc: api.Document = { name: ref.qualifiedPath },
+    readTime?: string
+  ) {
     this[docSymbol] = doc;
     this[readTimeSymbol] = readTime;
   }
 
-  get createTime(): Date {
-    return this[docSymbol].createTime && new Date(this[docSymbol].createTime);
+  get createTime(): Date | undefined {
+    const t = this[docSymbol].createTime;
+    return t ? new Date(t) : undefined;
   }
 
-  get updateTime(): Date {
-    return this[docSymbol].updateTime && new Date(this[docSymbol].updateTime);
+  get updateTime(): Date | undefined {
+    const t = this[docSymbol].updateTime;
+    return t ? new Date(t) : undefined;
   }
 
-  get readTime(): Date {
-    return this[readTimeSymbol] && new Date(this[readTimeSymbol]);
+  get readTime(): Date | undefined {
+    const t = this[readTimeSymbol];
+    return t ? new Date(t) : undefined;
   }
 
   get exists() {
     return !!this[docSymbol]?.fields;
   }
 
-  data() {
-    return this[docSymbol]?.fields && decode(this.ref.firestore, this[docSymbol].fields) || null;
+  data(): T | null {
+    const fields = this[docSymbol]?.fields;
+    return fields ? decode<T>(this.ref.firestore, fields) : null;
   }
 
   get(field: string): any {
-    let fields: api.MapValue | api.Value | undefined = this[docSymbol].fields;
+    let fields: api.MapValue | undefined = this[docSymbol].fields;
     const components = field.split('.');
     while (fields && components.length > 1) {
-      fields = (fields as api.MapValue)[components.shift()]?.mapValue.fields;
+      const next = components.shift()!;
+      fields = fields[next]?.mapValue?.fields;
     }
-    const value = fields?.[components[0]];
+    const last = components[0];
+    const value = fields && last !== undefined ? fields[last] : undefined;
     return value ? decodeValue(this.ref.firestore, value) : undefined;
   }
 }

--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -11,8 +11,8 @@ const scope = 'https://www.googleapis.com/auth/datastore';
 
 export class Firestore extends FirebaseService {
   basePath: string;
-  [transactionSymbol]: string = undefined;
-  [writesSymbol]: api.Write[] = undefined;
+  [transactionSymbol]?: string;
+  [writesSymbol]?: api.Write[];
 
   constructor(settings: Settings | ServiceAccountUnderscored, apiKey: string) {
     super('firestore', 'https://firestore.googleapis.com/v1', settings, apiKey);
@@ -28,10 +28,12 @@ export class Firestore extends FirebaseService {
   }
 
   async runTransaction<T>(updateFunction: () => Promise<T>, options?: api.TransactionOptions): Promise<T> {
-    this[transactionSymbol] = (await this.request('POST', ':beginTransaction', { options }) as {transaction: string}).transaction;
+    this[transactionSymbol] = (
+      (await this.request('POST', ':beginTransaction', { options })) as { transaction: string }
+    ).transaction;
     this[writesSymbol] = [];
     const result = await updateFunction();
-    (await this.request('POST', ':commit', { writes: this[writesSymbol], transaction: this[transactionSymbol] }));
+    await this.request('POST', ':commit', { writes: this[writesSymbol], transaction: this[transactionSymbol] });
     this[transactionSymbol] = undefined;
     this[writesSymbol] = undefined;
     return result;
@@ -43,7 +45,12 @@ export class Firestore extends FirebaseService {
 
   request<T>(method: HTTPMethod, path: string, search?: URLSearchParams, body?: object): Promise<T>;
   request<T>(method: HTTPMethod, path: string, body?: object): Promise<T>;
-  async request<T>(method: HTTPMethod, path?: string, searchOrBody?: URLSearchParams | object, body?: object): Promise<T> {
+  async request<T>(
+    method: HTTPMethod,
+    path: string,
+    searchOrBody?: URLSearchParams | object,
+    body?: object
+  ): Promise<T> {
     if (path && path[0] !== ':' && path[0] !== '/') path = '/' + path;
     path = this.basePath + path;
     return super.request(method, path, searchOrBody as URLSearchParams, body, scope);
@@ -53,17 +60,29 @@ export class Firestore extends FirebaseService {
     return createId(20);
   }
 
-  async batchGet(refs: DocumentReference[], fields?: string[], consistency?: ConsistencyOptions): Promise<DocumentSnapshot[]> {
+  async batchGet(
+    refs: DocumentReference[],
+    fields?: string[],
+    consistency?: ConsistencyOptions
+  ): Promise<DocumentSnapshot[]> {
     const mask = fields && { fieldPaths: fields };
-    const request: api.BatchGetRequest = { documents: refs.map(ref => ref.qualifiedPath), mask, ...consistency, transaction: this[transactionSymbol] };
-    const response: api.BatchGetResponse[] = await this.request('POST', ':batchGet',  request);
+    const request: api.BatchGetRequest = {
+      documents: refs.map(ref => ref.qualifiedPath),
+      mask,
+      ...consistency,
+      transaction: this[transactionSymbol],
+    };
+    const response: api.BatchGetResponse[] = await this.request('POST', ':batchGet', request);
     const docMap = new Map<string, api.BatchGetResponse>();
     // return in the same order as requested
-    response.forEach(result => docMap.set(result.missing || result.found.name, result));
+    response.forEach(result => {
+      const key = result.missing || result.found?.name;
+      if (key) docMap.set(key, result);
+    });
     return request.documents.map((name, i) => {
       const result = docMap.get(name);
-      const doc = result.missing ? null : result.found;
-      return new DocumentSnapshot(refs[i], doc, result.readTime);
+      const doc = result?.missing ? undefined : result?.found;
+      return new DocumentSnapshot(refs[i]!, doc, result?.readTime);
     });
   }
 }

--- a/src/firestore/reference.ts
+++ b/src/firestore/reference.ts
@@ -1,19 +1,25 @@
 import type {
-  api, DocumentData, OrderByDirection, PartialWithFieldValue, ReadTransactionOptions,
-  SetOptions, UpdateData, WhereFilterOp, WithFieldValue
+  api,
+  DocumentData,
+  OrderByDirection,
+  PartialWithFieldValue,
+  ReadTransactionOptions,
+  SetOptions,
+  UpdateData,
+  WhereFilterOp,
+  WithFieldValue,
 } from './types';
 import { DocumentSnapshot } from './document';
 import { Firestore } from './firestore';
 import { decodePath, encodeValue } from './serializer';
 import { createCursorSymbol, querySymbol, transactionSymbol } from './symbols';
 
-
- const directionOperators: {[k: string]: api.StructuredQueryDirection} = {
+const directionOperators: { [k: string]: api.StructuredQueryDirection } = {
   asc: 'ASCENDING',
   desc: 'DESCENDING',
 };
 
-const comparisonOperators: {[k: string]: api.FieldFilterOperator} = {
+const comparisonOperators: { [k: string]: api.FieldFilterOperator } = {
   '<': 'LESS_THAN',
   '<=': 'LESS_THAN_OR_EQUAL',
   '==': 'EQUAL',
@@ -26,30 +32,28 @@ const comparisonOperators: {[k: string]: api.FieldFilterOperator} = {
   'array-contains-any': 'ARRAY_CONTAINS_ANY',
 };
 
-const unaryOperators = {
+const unaryOperators: Record<'==' | '!=', Record<'null' | 'NaN', api.UnaryFilterOperator>> = {
   '==': {
-    null: 'IS_NULL' as api.UnaryFilterOperator,
-    NaN: 'IS_NAN' as api.UnaryFilterOperator,
+    null: 'IS_NULL',
+    NaN: 'IS_NAN',
   },
   '!=': {
-    null: 'IS_NOT_NULL' as api.UnaryFilterOperator,
-    NaN: 'IS_NOT_NAN' as api.UnaryFilterOperator,
+    null: 'IS_NOT_NULL',
+    NaN: 'IS_NOT_NAN',
   },
 };
 
-const inequalityFilters = new Set([
-  'GREATER_THAN',
-  'GREATER_THAN_OR_EQUAL',
-  'LESS_THAN',
-  'LESS_THAN_OR_EQUAL',
-]);
+const inequalityFilters = new Set(['GREATER_THAN', 'GREATER_THAN_OR_EQUAL', 'LESS_THAN', 'LESS_THAN_OR_EQUAL']);
 
 export enum FieldPath {
   documentId = '__name__',
 }
 
 export class Reference {
-  constructor(readonly firestore: Firestore, path: string | string[]) {
+  constructor(
+    readonly firestore: Firestore,
+    path: string | string[]
+  ) {
     const segments = typeof path === 'string' ? trim(path).split('/') : path;
     if (segments.length % 2 === 0) {
       return new DocumentReference(firestore, segments);
@@ -62,9 +66,14 @@ export class Reference {
 export class DocumentReference<T = DocumentData> {
   readonly segments: string[];
 
-  constructor(readonly firestore: Firestore, path: string | string[], readonly transactionOptions?: ReadTransactionOptions) {
+  constructor(
+    readonly firestore: Firestore,
+    path: string | string[],
+    readonly transactionOptions?: ReadTransactionOptions
+  ) {
     const segments = typeof path === 'string' ? trim(path).split('/').filter(Boolean) : path;
-    if (segments.length % 2 !== 0) throw new Error('A document reference must have an even number of segments, received ' + segments.join('/'));
+    if (segments.length % 2 !== 0)
+      throw new Error('A document reference must have an even number of segments, received ' + segments.join('/'));
     this.segments = segments;
   }
 
@@ -73,7 +82,7 @@ export class DocumentReference<T = DocumentData> {
   }
 
   get id(): string {
-    return this.segments[this.segments.length - 1] || null;
+    return this.segments[this.segments.length - 1]!;
   }
 
   get path() {
@@ -89,7 +98,7 @@ export class DocumentReference<T = DocumentData> {
   }
 
   async get(fields?: string[]) {
-    return (await this.firestore.batchGet([ this ], fields, this.transactionOptions))[0];
+    return (await this.firestore.batchGet([this], fields, this.transactionOptions))[0]!;
   }
 
   async listCollections(): Promise<CollectionReference[]> {
@@ -101,7 +110,7 @@ export class DocumentReference<T = DocumentData> {
     return response.collectionIds.map(id => this.collection(id));
   }
 
-  async create(data: WithFieldValue<T>): Promise<Date> {
+  async create(data: WithFieldValue<T>): Promise<Date | undefined> {
     return (await this.firestore.batch().create(this, data).commit())[0];
   }
 
@@ -109,25 +118,23 @@ export class DocumentReference<T = DocumentData> {
     await this.firestore.batch().delete(this).commit();
   }
 
-  set(data: PartialWithFieldValue<T>, options: SetOptions): Promise<Date>;
-  set(data: WithFieldValue<T>): Promise<Date>;
-  async set(data: PartialWithFieldValue<T>, options?: SetOptions): Promise<Date> {
+  set(data: PartialWithFieldValue<T>, options: SetOptions): Promise<Date | undefined>;
+  set(data: WithFieldValue<T>): Promise<Date | undefined>;
+  async set(data: PartialWithFieldValue<T>, options?: SetOptions): Promise<Date | undefined> {
     return (await this.firestore.batch().set(this, data, options).commit())[0];
   }
 
-  async update(data: UpdateData<T>): Promise<Date> {
+  async update(data: UpdateData<T>): Promise<Date | undefined> {
     return (await this.firestore.batch().update(this, data).commit())[0];
   }
 }
 
-
 export class QuerySnapshot<T = DocumentData> {
-
   constructor(
     readonly query: Query<T>,
     readonly readTime: Date,
     readonly size: number,
-    readonly docs: Array<DocumentSnapshot<T>>,
+    readonly docs: Array<DocumentSnapshot<T>>
   ) {}
 
   forEach(callback: (result: DocumentSnapshot<T>) => void, thisArg?: unknown): void {
@@ -137,17 +144,19 @@ export class QuerySnapshot<T = DocumentData> {
   }
 }
 
-
-export interface QueryOptions extends api.StructuredQuery {
+export interface QueryOptions extends Omit<api.StructuredQuery, 'orderBy'> {
   filters: api.Filter[];
+  orderBy: api.StructuredQueryOrder[];
   reverse?: true;
 }
 
-
 export class Query<T = DocumentData> {
-  protected [querySymbol]: QueryOptions = undefined;
+  protected [querySymbol]: QueryOptions;
 
-  constructor(readonly ref: CollectionReference<T>, query: QueryOptions) {
+  constructor(
+    readonly ref: CollectionReference<T>,
+    query: QueryOptions
+  ) {
     this[querySymbol] = query;
   }
 
@@ -158,13 +167,13 @@ export class Query<T = DocumentData> {
       if (typeof value === 'string') value = this.ref.doc(value);
       else if (Array.isArray(value) && typeof value[0] === 'string') value = value.map(value => this.ref.doc(value));
     }
-    if ((opStr === '==' || opStr === '!=') && (value === null || typeof value === 'number' && isNaN(value))) {
-      const op = unaryOperators[opStr][value as any] as api.UnaryFilterOperator;
-      filter = { unaryFilter: { field: { fieldPath }, op } };
+    if ((opStr === '==' || opStr === '!=') && (value === null || (typeof value === 'number' && isNaN(value)))) {
+      const key: 'null' | 'NaN' = value === null ? 'null' : 'NaN';
+      filter = { unaryFilter: { field: { fieldPath }, op: unaryOperators[opStr][key] } };
     } else {
       filter = { fieldFilter: { field: { fieldPath }, op: comparisonOperators[opStr], value: encodeValue(value) } };
     }
-    return new Query<T>(this.ref, { ...this[querySymbol], filters: [ ...this[querySymbol].filters, filter ] });
+    return new Query<T>(this.ref, { ...this[querySymbol], filters: [...this[querySymbol].filters, filter] });
   }
 
   select(...fieldPaths: string[]): Query<T> {
@@ -176,9 +185,10 @@ export class Query<T = DocumentData> {
   }
 
   orderBy(fieldPath: string, directionStr?: OrderByDirection): Query<T> {
+    const direction = directionStr ? directionOperators[directionStr] : undefined;
     return new Query(this.ref, {
       ...this[querySymbol],
-      orderBy: [ ...this[querySymbol].orderBy, { field: { fieldPath }, direction: directionOperators[directionStr] } ],
+      orderBy: [...this[querySymbol].orderBy, { field: { fieldPath }, direction }],
     });
   }
 
@@ -196,22 +206,37 @@ export class Query<T = DocumentData> {
   }
 
   startAt(...fieldValuesOrDocumentSnapshot: Array<DocumentSnapshot<unknown> | unknown>): Query<T> {
-    return new Query(this.ref, { ...this[querySymbol], startAt: this[createCursorSymbol](fieldValuesOrDocumentSnapshot, true) });
+    return new Query(this.ref, {
+      ...this[querySymbol],
+      startAt: this[createCursorSymbol](fieldValuesOrDocumentSnapshot, true),
+    });
   }
 
   startAfter(...fieldValuesOrDocumentSnapshot: Array<DocumentSnapshot<unknown> | unknown>): Query<T> {
-    return new Query(this.ref, { ...this[querySymbol], startAt: this[createCursorSymbol](fieldValuesOrDocumentSnapshot, false) });
+    return new Query(this.ref, {
+      ...this[querySymbol],
+      startAt: this[createCursorSymbol](fieldValuesOrDocumentSnapshot, false),
+    });
   }
 
   endAt(...fieldValuesOrDocumentSnapshot: Array<DocumentSnapshot<unknown> | unknown>): Query<T> {
-    return new Query(this.ref, { ...this[querySymbol], endAt: this[createCursorSymbol](fieldValuesOrDocumentSnapshot, true) });
+    return new Query(this.ref, {
+      ...this[querySymbol],
+      endAt: this[createCursorSymbol](fieldValuesOrDocumentSnapshot, true),
+    });
   }
 
   endAfter(...fieldValuesOrDocumentSnapshot: Array<DocumentSnapshot<unknown> | unknown>): Query<T> {
-    return new Query(this.ref, { ...this[querySymbol], endAt: this[createCursorSymbol](fieldValuesOrDocumentSnapshot, false) });
+    return new Query(this.ref, {
+      ...this[querySymbol],
+      endAt: this[createCursorSymbol](fieldValuesOrDocumentSnapshot, false),
+    });
   }
 
-  private [createCursorSymbol](cursorValuesOrDocumentSnapshot: Array<DocumentSnapshot | unknown>, before: boolean): api.Cursor {
+  private [createCursorSymbol](
+    cursorValuesOrDocumentSnapshot: Array<DocumentSnapshot | unknown>,
+    before: boolean
+  ): api.Cursor {
     const fieldOrders = getFieldOrders(this[querySymbol]);
     let fieldValues: unknown[];
 
@@ -223,8 +248,7 @@ export class Query<T = DocumentData> {
 
     if (fieldValues.length > fieldOrders.length) {
       throw new Error(
-        'Too many cursor values specified. The specified ' +
-          'values must match the orderBy() constraints of the query.'
+        'Too many cursor values specified. The specified ' + 'values must match the orderBy() constraints of the query.'
       );
     }
 
@@ -232,15 +256,17 @@ export class Query<T = DocumentData> {
 
     for (let i = 0; i < fieldValues.length; ++i) {
       let fieldValue = fieldValues[i];
+      const fieldOrder = fieldOrders[i]!;
 
-      if (fieldOrders[i].field.fieldPath === FieldPath.documentId && typeof fieldValue === 'string') {
+      if (fieldOrder.field?.fieldPath === FieldPath.documentId && typeof fieldValue === 'string') {
         fieldValue = this.ref.doc(fieldValue);
       }
       if (typeof fieldValue === 'undefined') {
-        throw new Error('A cursor value must be provided for the ' + fieldOrders[i].field.fieldPath + ' field.');
+        throw new Error('A cursor value must be provided for the ' + fieldOrder.field?.fieldPath + ' field.');
       }
 
-      cursor.values!.push(encodeValue(fieldValue));
+      const encoded = encodeValue(fieldValue);
+      if (encoded) cursor.values.push(encoded);
     }
 
     return cursor;
@@ -260,23 +286,37 @@ export class Query<T = DocumentData> {
         throw new Error('limitToLast() queries require specifying at least one orderBy() clause.');
       }
       // Flip the orderBy directions since we want the last results
-      query.orderBy = query.orderBy.map(({ field, direction }) =>
-        ({ field, direction: direction === 'DESCENDING' ? 'ASCENDING' : 'DESCENDING' }));
+      query.orderBy = query.orderBy.map(({ field, direction }) => ({
+        field,
+        direction: direction === 'DESCENDING' ? 'ASCENDING' : 'DESCENDING',
+      }));
       // Swap the cursors to match the now-flipped query ordering.
       query.startAt = query.endAt ? { values: query.endAt.values, before: !query.endAt.before } : undefined;
       query.endAt = query.startAt ? { values: query.startAt.values, before: !query.startAt.before } : undefined;
     }
-    const response: api.RunQueryResponse[] = await this.ref.firestore.request('POST', `${this.ref.parent.path}:runQuery`, {
-      structuredQuery: query, transaction: this.ref.firestore[transactionSymbol],
-    });
+    const response: api.RunQueryResponse[] = await this.ref.firestore.request(
+      'POST',
+      `${this.ref.parent.path}:runQuery`,
+      {
+        structuredQuery: query,
+        transaction: this.ref.firestore[transactionSymbol],
+      }
+    );
 
-    const readTime = new Date(response[0].readTime);
+    const readTime = new Date(response[0]!.readTime);
     if (response[0]?.error) throw new Error(response[0].error.message);
     if (response[0]?.skippedResults) response.shift();
     if (reverse) response.reverse();
-    const docs = response.filter(e => e.document).map(e =>
-      new DocumentSnapshot<T>(this.ref.doc(decodePath(e.document.name).replace(this.ref.path, '')), e.document, e.readTime)
-    );
+    const docs = response
+      .filter((e): e is api.RunQueryResponse & { document: api.Document } => !!e.document)
+      .map(
+        e =>
+          new DocumentSnapshot<T>(
+            this.ref.doc(decodePath(e.document.name).replace(this.ref.path, '')),
+            e.document,
+            e.readTime
+          )
+      );
     return new QuerySnapshot<T>(this, readTime, response.length, docs);
   }
 
@@ -300,14 +340,22 @@ export class Query<T = DocumentData> {
   }
 }
 
-
-export class CollectionReference<T = DocumentData> extends Query {
+export class CollectionReference<T = DocumentData> extends Query<T> {
   readonly segments: string[];
 
-  constructor(readonly firestore: Firestore, path: string | string[], readonly transactionOptions?: ReadTransactionOptions) {
+  constructor(
+    readonly firestore: Firestore,
+    path: string | string[],
+    readonly transactionOptions?: ReadTransactionOptions
+  ) {
     const segments = typeof path === 'string' ? trim(path).split('/') : path;
-    if (segments.length % 2 !== 1) throw new Error('A collection reference must have an odd number of segments, received ' + segments.join('/'));
-    super(null, { from: [{ collectionId: segments[segments.length - 1] }], filters: [], orderBy: [] });
+    if (segments.length % 2 !== 1)
+      throw new Error('A collection reference must have an odd number of segments, received ' + segments.join('/'));
+    super(null as unknown as CollectionReference<T>, {
+      from: [{ collectionId: segments[segments.length - 1]! }],
+      filters: [],
+      orderBy: [],
+    });
     (this.ref as any) = this;
     this.segments = segments;
   }
@@ -322,7 +370,7 @@ export class CollectionReference<T = DocumentData> extends Query {
   }
 
   get id(): string {
-    return this.segments[this.segments.length - 1] || null;
+    return this.segments[this.segments.length - 1]!;
   }
 
   get path() {
@@ -357,12 +405,13 @@ function trim(path: string) {
   return path.replace(/^\/|\/$/g, '');
 }
 
-function getFieldOrders(query: QueryOptions) {
+function getFieldOrders(query: QueryOptions): api.StructuredQueryOrder[] {
   const fieldOrders = query.orderBy.slice();
   if (!fieldOrders.length) {
     for (const fieldFilter of query.filters) {
-      if (inequalityFilters.has(fieldFilter.fieldFilter?.op)) {
-        fieldOrders.push({ field: fieldFilter.fieldFilter.field });
+      const op = fieldFilter.fieldFilter?.op;
+      if (op && inequalityFilters.has(op)) {
+        fieldOrders.push({ field: fieldFilter.fieldFilter!.field });
         break;
       }
     }
@@ -374,13 +423,15 @@ function extractFieldValues(documentSnapshot: DocumentSnapshot, fieldOrders: api
   const fieldValues: unknown[] = [];
 
   for (const fieldOrder of fieldOrders) {
-    if (fieldOrder.field.fieldPath === FieldPath.documentId) {
+    const fieldPath = fieldOrder.field?.fieldPath;
+    if (!fieldPath) continue;
+    if (fieldPath === FieldPath.documentId) {
       fieldValues.push(documentSnapshot.ref);
     } else {
-      const fieldValue = documentSnapshot.get(fieldOrder.field.fieldPath);
+      const fieldValue = documentSnapshot.get(fieldPath);
       if (fieldValue === undefined) {
         throw new Error(
-          `Field "${fieldOrder.field}" is missing in the provided DocumentSnapshot. ` +
+          `Field "${fieldPath}" is missing in the provided DocumentSnapshot. ` +
             'Please provide a document that contains values for all specified ' +
             'orderBy() and where() constraints.'
         );

--- a/src/firestore/serializer.ts
+++ b/src/firestore/serializer.ts
@@ -8,26 +8,29 @@ export function encode(map: DocumentData, collector?: UpdateCollector): api.MapV
   const fields: api.MapValue = {};
   Object.entries(map).forEach(([key, value]) => {
     collector?.enterField(key);
-    if (value !== undefined) fields[key] = encodeValue(value, collector);
+    if (value !== undefined) {
+      const encoded = encodeValue(value, collector);
+      if (encoded !== undefined) fields[key] = encoded;
+    }
     // Maps contribute dotted leaf paths via recursion, so adding the map's
     // own path would cause merge to overwrite sibling fields. Arrays must
     // add their own path: Firestore fieldPaths can't address array elements,
     // so arrays are always replaced whole at the parent path.
-    const shouldAddMask = !fields[key] || !fields[key].mapValue;
+    const shouldAddMask = !fields[key] || !fields[key]!.mapValue;
     collector?.leaveField(shouldAddMask);
   });
   return fields;
 }
 
-export function encodeValue(value: any, collector?: UpdateCollector) {
+export function encodeValue(value: any, collector?: UpdateCollector): api.Value | undefined {
   if (value === null) return { nullValue: null };
   if (typeof value === 'boolean') return { booleanValue: value };
   if (typeof value === 'number' && !(value === 0 && 1 / value === 1 / -0) && Number.isSafeInteger(value))
     return { integerValue: '' + value };
-  if (typeof value === 'number') return { doubleValue: '' + value };
+  if (typeof value === 'number') return { doubleValue: value };
   if (value instanceof FieldValue) {
     collector?.transform(value);
-    return;
+    return undefined;
   }
   if (value instanceof Date) return { timestampValue: value.toISOString() };
   if (value.qualifiedPath) return { referenceValue: value.qualifiedPath };
@@ -40,7 +43,10 @@ export function encodeValue(value: any, collector?: UpdateCollector) {
   // cannot address elements by index, so any inner paths the elements
   // registered (e.g. "books.id") would be invalid. Arrays are replaced
   // whole at the parent field path.
-  if (Array.isArray(value)) return { arrayValue: { values: value.map(v => encodeValue(v)) } };
+  if (Array.isArray(value)) {
+    const values = value.map(v => encodeValue(v)).filter((v): v is api.Value => v !== undefined);
+    return { arrayValue: { values } };
+  }
   if (typeof value === 'object') return { mapValue: { fields: encode(value, collector) } };
   throw new Error(`Unsupported value type: ${typeof value}`);
 }
@@ -54,8 +60,10 @@ export function decode<T = DocumentData>(firestore: Firestore, fields: api.MapVa
   return obj as T;
 }
 
-export function decodeValue(firestore: Firestore, valueObj: api.Value) {
-  const [key, value] = Object.entries(valueObj).pop();
+export function decodeValue(firestore: Firestore, valueObj: api.Value): any {
+  const entry = Object.entries(valueObj).pop();
+  if (!entry) return undefined;
+  const [key, value] = entry;
   switch (key) {
     case 'nullValue':
       return null;
@@ -64,7 +72,7 @@ export function decodeValue(firestore: Firestore, valueObj: api.Value) {
     case 'integerValue':
       return parseInt(value, 10);
     case 'doubleValue':
-      return parseFloat(value);
+      return typeof value === 'number' ? value : parseFloat(value);
     case 'timestampValue':
       return new Date(value);
     case 'stringValue':
@@ -74,7 +82,7 @@ export function decodeValue(firestore: Firestore, valueObj: api.Value) {
     case 'geoPointValue':
       return value;
     case 'arrayValue':
-      return value.values?.map(decodeValue.bind(null, firestore)) || [];
+      return value.values?.map((v: api.Value) => decodeValue(firestore, v)) || [];
     case 'mapValue':
       return decode(firestore, value.fields);
     case 'referenceValue':

--- a/src/firestore/symbols.ts
+++ b/src/firestore/symbols.ts
@@ -1,4 +1,3 @@
-
 export const transactionSymbol = Symbol();
 export const querySymbol = Symbol();
 export const writesSymbol = Symbol();

--- a/src/firestore/types.ts
+++ b/src/firestore/types.ts
@@ -4,77 +4,68 @@ import type { FieldValue } from './field-value';
  * Document data (for use with `DocumentReference.set()`) consists of fields
  * mapped to values.
  */
-export type DocumentData = {[field: string]: any};
+export type DocumentData = { [field: string]: any };
 
 /**
-* Similar to Typescript's `Partial<T>`, but allows nested fields to be
-* omitted and FieldValues to be passed in as property values.
-*/
+ * Similar to Typescript's `Partial<T>`, but allows nested fields to be
+ * omitted and FieldValues to be passed in as property values.
+ */
 export type PartialWithFieldValue<T> =
   | Partial<T>
-  | (T extends Primitive
-      ? T
-      : T extends {}
-      ? {[K in keyof T]?: PartialWithFieldValue<T[K]> | FieldValue}
-      : never);
+  | (T extends Primitive ? T : T extends {} ? { [K in keyof T]?: PartialWithFieldValue<T[K]> | FieldValue } : never);
 
 /**
-* Allows FieldValues to be passed in as a property value while maintaining
-* type safety.
-*/
+ * Allows FieldValues to be passed in as a property value while maintaining
+ * type safety.
+ */
 export type WithFieldValue<T> =
   | T
-  | (T extends Primitive
-      ? T
-      : T extends {}
-      ? {[K in keyof T]: WithFieldValue<T[K]> | FieldValue}
-      : never);
+  | (T extends Primitive ? T : T extends {} ? { [K in keyof T]: WithFieldValue<T[K]> | FieldValue } : never);
 
 /**
-* Update data (for use with [update]{@link DocumentReference#update})
-* that contains paths mapped to values. Fields that contain dots reference
-* nested fields within the document. FieldValues can be passed in
-* as property values.
-*
-* You can update a top-level field in your document by using the field name
-* as a key (e.g. `foo`). The provided value completely replaces the contents
-* for this field.
-*
-* You can also update a nested field directly by using its field path as a
-* key (e.g. `foo.bar`). This nested field update replaces the contents at
-* `bar` but does not modify other data under `foo`.
-*/
+ * Update data (for use with [update]{@link DocumentReference#update})
+ * that contains paths mapped to values. Fields that contain dots reference
+ * nested fields within the document. FieldValues can be passed in
+ * as property values.
+ *
+ * You can update a top-level field in your document by using the field name
+ * as a key (e.g. `foo`). The provided value completely replaces the contents
+ * for this field.
+ *
+ * You can also update a nested field directly by using its field path as a
+ * key (e.g. `foo.bar`). This nested field update replaces the contents at
+ * `bar` but does not modify other data under `foo`.
+ */
 export type UpdateData<T> = T extends Primitive
   ? T
   : T extends {}
-  ? {[K in keyof T]?: UpdateData<T[K]> | FieldValue} & NestedUpdateFields<T>
-  : Partial<T>;
+    ? { [K in keyof T]?: UpdateData<T[K]> | FieldValue } & NestedUpdateFields<T>
+    : Partial<T>;
 
 /** Primitive types. */
 export type Primitive = string | number | boolean | undefined | null;
 
 /**
-* For each field (e.g. 'bar'), find all nested keys (e.g. {'bar.baz': T1,
-* 'bar.qux': T2}). Intersect them together to make a single map containing
-* all possible keys that are all marked as optional
-*/
-export type NestedUpdateFields<T extends Record<string, unknown>> =
-  UnionToIntersection<
-    {
-      [K in keyof T & string]: ChildUpdateFields<K, T[K]>;
-    }[keyof T & string] // Also include the generated prefix-string keys.
-  >;
+ * For each field (e.g. 'bar'), find all nested keys (e.g. {'bar.baz': T1,
+ * 'bar.qux': T2}). Intersect them together to make a single map containing
+ * all possible keys that are all marked as optional
+ */
+export type NestedUpdateFields<T extends Record<string, unknown>> = UnionToIntersection<
+  {
+    [K in keyof T & string]: ChildUpdateFields<K, T[K]>;
+  }[keyof T & string] // Also include the generated prefix-string keys.
+>;
 
 /**
-* Helper for calculating the nested fields for a given type T1. This is needed
-* to distribute union types such as `undefined | {...}` (happens for optional
-* props) or `{a: A} | {b: B}`.
-*
-* In this use case, `V` is used to distribute the union types of `T[K]` on
-* `Record`, since `T[K]` is evaluated as an expression and not distributed.
-*
-* See https://www.typescriptlang.org/docs/handbook/advanced-types.html#distributive-conditional-types
-*/
+ * Helper for calculating the nested fields for a given type T1. This is needed
+ * to distribute union types such as `undefined | {...}` (happens for optional
+ * props) or `{a: A} | {b: B}`.
+ *
+ * In this use case, `V` is used to distribute the union types of `T[K]` on
+ * `Record`, since `T[K]` is evaluated as an expression and not distributed.
+ *
+ * See https://www.typescriptlang.org/docs/handbook/advanced-types.html#distributive-conditional-types
+ */
 export type ChildUpdateFields<K extends string, V> =
   // Only allow nesting for map values
   V extends Record<string, unknown>
@@ -85,46 +76,40 @@ export type ChildUpdateFields<K extends string, V> =
       never;
 
 /**
-* Returns a new map where every key is prefixed with the outer key appended
-* to a dot.
-*/
-export type AddPrefixToKeys<
-  Prefix extends string,
-  T extends Record<string, unknown>
-> =
+ * Returns a new map where every key is prefixed with the outer key appended
+ * to a dot.
+ */
+export type AddPrefixToKeys<Prefix extends string, T extends Record<string, unknown>> =
   // Remap K => Prefix.K. See https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#key-remapping-via-as
-  {[K in keyof T & string as `${Prefix}.${K}`]+?: T[K]};
+  { [K in keyof T & string as `${Prefix}.${K}`]+?: T[K] };
 
 /**
-* Given a union type `U = T1 | T2 | ...`, returns an intersected type
-* `(T1 & T2 & ...)`.
-*
-* Uses distributive conditional types and inference from conditional types.
-* This works because multiple candidates for the same type variable in
-* contra-variant positions causes an intersection type to be inferred.
-* https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-inference-in-conditional-types
-* https://stackoverflow.com/questions/50374908/transform-union-type-to-intersection-type
-*/
-export type UnionToIntersection<U> = (
-  U extends unknown ? (k: U) => void : never
-) extends (k: infer I) => void
+ * Given a union type `U = T1 | T2 | ...`, returns an intersected type
+ * `(T1 & T2 & ...)`.
+ *
+ * Uses distributive conditional types and inference from conditional types.
+ * This works because multiple candidates for the same type variable in
+ * contra-variant positions causes an intersection type to be inferred.
+ * https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-inference-in-conditional-types
+ * https://stackoverflow.com/questions/50374908/transform-union-type-to-intersection-type
+ */
+export type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (k: infer I) => void
   ? I
   : never;
 
 export type SetOptions = { readonly merge?: boolean };
 
 export type WhereFilterOp =
-    | '<'
-    | '<='
-    | '=='
-    | '!='
-    | '>='
-    | '>'
-    | 'array-contains'
-    | 'in'
-    | 'not-in'
-    | 'array-contains-any';
-
+  | '<'
+  | '<='
+  | '=='
+  | '!='
+  | '>='
+  | '>'
+  | 'array-contains'
+  | 'in'
+  | 'not-in'
+  | 'array-contains-any';
 
 export type OrderByDirection = 'desc' | 'asc';
 
@@ -186,15 +171,15 @@ export namespace api {
   }
 
   export interface BatchGetResponse {
-    transaction?: string,
-    readTime: string,
+    transaction?: string;
+    readTime: string;
     found?: Document;
     missing?: string;
   }
 
   export interface BatchWriteRequest {
     writes: Write[];
-    labels?: {[key: string]: string};
+    labels?: { [key: string]: string };
   }
 
   export interface BatchWriteResponse {
@@ -271,8 +256,8 @@ export namespace api {
   }
 
   export interface CollectionSelector {
-    collectionId: string,
-    allDescendants?: boolean
+    collectionId: string;
+    allDescendants?: boolean;
   }
 
   export interface Cursor {
@@ -282,9 +267,9 @@ export namespace api {
 
   export interface StructuredQuery {
     select?: StructuredQueryProjection;
-    from?: [CollectionSelector],
+    from?: [CollectionSelector];
     where?: Filter;
-    orderBy?: StructuredQueryOrder[],
+    orderBy?: StructuredQueryOrder[];
     startAt?: Cursor;
     endAt?: Cursor;
     offset?: number;
@@ -305,10 +290,21 @@ export namespace api {
     direction?: StructuredQueryDirection;
   }
 
-  export type CompositeFilterOperator = 'OPERATOR_UNSPECIFIED'| 'AND';
-  export type FieldFilterOperator = 'OPERATOR_UNSPECIFIED'| 'LESS_THAN'| 'LESS_THAN_OR_EQUAL'| 'GREATER_THAN'| 'GREATER_THAN_OR_EQUAL'| 'EQUAL'| 'NOT_EQUAL'| 'ARRAY_CONTAINS'| 'IN'| 'ARRAY_CONTAINS_ANY'| 'NOT_IN';
-  export type UnaryFilterOperator = 'OPERATOR_UNSPECIFIED'| 'IS_NAN'| 'IS_NULL'| 'IS_NOT_NAN'| 'IS_NOT_NULL';
-  export type StructuredQueryDirection = 'DIRECTION_UNSPECIFIED'| 'ASCENDING'| 'DESCENDING';
+  export type CompositeFilterOperator = 'OPERATOR_UNSPECIFIED' | 'AND';
+  export type FieldFilterOperator =
+    | 'OPERATOR_UNSPECIFIED'
+    | 'LESS_THAN'
+    | 'LESS_THAN_OR_EQUAL'
+    | 'GREATER_THAN'
+    | 'GREATER_THAN_OR_EQUAL'
+    | 'EQUAL'
+    | 'NOT_EQUAL'
+    | 'ARRAY_CONTAINS'
+    | 'IN'
+    | 'ARRAY_CONTAINS_ANY'
+    | 'NOT_IN';
+  export type UnaryFilterOperator = 'OPERATOR_UNSPECIFIED' | 'IS_NAN' | 'IS_NULL' | 'IS_NOT_NAN' | 'IS_NOT_NULL';
+  export type StructuredQueryDirection = 'DIRECTION_UNSPECIFIED' | 'ASCENDING' | 'DESCENDING';
 
   export enum ServerValue {
     SERVER_VALUE_UNSPECIFIED = 'SERVER_VALUE_UNSPECIFIED',
@@ -316,10 +312,10 @@ export namespace api {
   }
 
   export interface Document {
-    name: string,
-    fields: MapValue,
-    createTime?: string,
-    updateTime?: string
+    name: string;
+    fields?: MapValue;
+    createTime?: string;
+    updateTime?: string;
   }
 
   export interface DocumentMask {
@@ -369,7 +365,7 @@ export namespace api {
   }
 
   export interface RunQueryResponse {
-    error?: { code: number; message: string; status: string; };
+    error?: { code: number; message: string; status: string };
     transaction?: string;
     document?: Document;
     readTime: string;
@@ -380,12 +376,9 @@ export namespace api {
   export interface Status {
     code: number;
     message: string;
-    details:{
+    details?: {
       '@type': string;
       [key: string]: any;
     }[];
   }
 }
-
-
-

--- a/src/firestore/write-batch.ts
+++ b/src/firestore/write-batch.ts
@@ -19,7 +19,7 @@ export class WriteBatch {
     return this[updateSymbol](ref, data, UpdateType.create);
   }
 
-  set<T = DocumentData>(ref: DocumentReference<T>, data: PartialWithFieldValue<T>, options: SetOptions): this;
+  set<T = DocumentData>(ref: DocumentReference<T>, data: PartialWithFieldValue<T>, options?: SetOptions): this;
   set<T = DocumentData>(ref: DocumentReference<T>, data: WithFieldValue<T>): this;
   set<T = DocumentData>(ref: DocumentReference<T>, data: PartialWithFieldValue<T>, options?: SetOptions): this {
     return this[updateSymbol](ref, data, options?.merge ? UpdateType.update : UpdateType.set);
@@ -37,12 +37,12 @@ export class WriteBatch {
     return this;
   }
 
-  async commit(): Promise<Date[]> {
+  async commit(): Promise<Array<Date | undefined>> {
     Object.freeze(this[writesSymbol]);
     if (this.firestore[writesSymbol]) {
       // transaction
-      this.firestore[writesSymbol].push(...this[writesSymbol]);
-      return;
+      this.firestore[writesSymbol]!.push(...this[writesSymbol]);
+      return [];
     }
     const response = await this.firestore.request<api.BatchWriteResponse>('POST', ':batchWrite', {
       writes: this[writesSymbol],
@@ -63,7 +63,7 @@ export class WriteBatch {
     if (failures.length > 0) {
       throw new BatchWriteError(failures);
     }
-    return response.writeResults.map(result => (result.updateTime && new Date(result.updateTime)) || undefined);
+    return response.writeResults.map(result => (result.updateTime ? new Date(result.updateTime) : undefined));
   }
 
   [updateSymbol]<T = DocumentData>(ref: DocumentReference<T>, data: any, type: UpdateType): this {

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,6 +1,13 @@
 import { StatusError } from './status-error';
 import { Aud, getTokenGetter } from './tokens';
-import type { HTTPMethod, ServiceAccount, ServiceAccountUnderscored, Settings, TokenGetter, UserAccount } from './types';
+import type {
+  HTTPMethod,
+  ServiceAccount,
+  ServiceAccountUnderscored,
+  Settings,
+  TokenGetter,
+  UserAccount,
+} from './types';
 
 export class FirebaseService {
   getToken: TokenGetter;
@@ -36,10 +43,10 @@ export class FirebaseService {
   request<T>(method: HTTPMethod, path: string, body?: object, authorized?: string): Promise<T>;
   async request<T>(
     method: HTTPMethod,
-    path?: string,
+    path: string,
     searchOrBody?: URLSearchParams | object,
-    body?: object | string,
-    authorized?: string
+    body?: object | string | boolean,
+    authorized?: string | boolean
   ): Promise<T> {
     if (typeof body === 'boolean' || typeof body === 'string') {
       authorized = body;
@@ -49,19 +56,16 @@ export class FirebaseService {
     searchParams.set('key', this.apiKey);
     if (!body && searchOrBody && !(searchOrBody instanceof URLSearchParams)) body = searchOrBody;
     if (path && path[0] !== ':' && path[0] !== '/') path = '/' + path;
-    let Authorization: string | undefined;
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (typeof authorized === 'string') {
-      Authorization = `Bearer ${await this.getToken({ scope: authorized })}`;
+      headers.Authorization = `Bearer ${await this.getToken({ scope: authorized })}`;
     } else if (authorized !== false) {
-      Authorization = `Bearer ${await this.getToken()}`;
+      headers.Authorization = `Bearer ${await this.getToken()}`;
     }
     const response = await fetch(`${this.apiUrl}${path}?${searchParams}`, {
       method,
-      body: JSON.stringify(body),
-      headers: {
-        Authorization,
-        'Content-Type': 'application/json',
-      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      headers,
     });
     const data = (await response.json()) as any;
     if (data.error) {
@@ -74,10 +78,10 @@ export class FirebaseService {
   userRequest<T>(method: HTTPMethod, path: string, body?: object): Promise<T>;
   async userRequest<T>(
     method: HTTPMethod,
-    path?: string,
+    path: string,
     searchOrBody?: URLSearchParams | object,
     body?: object
   ): Promise<T> {
-    return this.request(method, path, searchOrBody as any, body, false);
+    return this.request(method, path, searchOrBody as URLSearchParams, body, false);
   }
 }

--- a/src/storage/bucket.ts
+++ b/src/storage/bucket.ts
@@ -32,11 +32,7 @@ export class Bucket {
    * @param options Optional parameters for listing (prefix, maxResults, etc.)
    * @returns An array of file metadata objects
    */
-  async list(options?: {
-    prefix?: string;
-    maxResults?: number;
-    pageToken?: string;
-  }): Promise<BucketFile[]> {
+  async list(options?: { prefix?: string; maxResults?: number; pageToken?: string }): Promise<BucketFile[]> {
     const token = await this.storage.getToken();
 
     const params = new URLSearchParams();
@@ -58,7 +54,7 @@ export class Bucket {
       throw new Error(`Failed to list files: ${response.statusText}`);
     }
 
-    const data = await response.json() as { items?: BucketFile[] };
+    const data = (await response.json()) as { items?: BucketFile[] };
     return data.items || [];
   }
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -12,12 +12,12 @@ const aud = {
 export type Aud = Omit<typeof aud, 'oauth'>;
 
 export function getTokenGetter(settings: ServiceAccount, service: keyof Aud): TokenGetter {
-  let token: string;
-  let tokenExp: number;
+  let token = '';
+  let tokenExp = 0;
 
   const getOauthToken = getOauthTokenGetter(settings);
 
-  return async function getToken(claims?: Record<string, any>) {
+  return async function getToken(claims?: Record<string, any>): Promise<string> {
     if (claims) {
       return await (claims.scope ? getOauthToken(claims.scope) : createToken(settings, service, claims));
     }
@@ -34,11 +34,11 @@ export function getOauthTokenGetter(settings: ServiceAccount) {
   const tokens = new Map<string, string>();
   const tokenExps = new Map<string, number>();
 
-  return async function getOauthToken(scope: string) {
+  return async function getOauthToken(scope: string): Promise<string> {
     let token = tokens.get(scope);
     const tokenExp = tokenExps.get(scope);
 
-    if (!tokenExp || now() > tokenExp - 60) {
+    if (!token || !tokenExp || now() > tokenExp - 60) {
       const oauthToken = await createToken(settings, 'oauth', { scope });
       const response = await fetch('https://oauth2.googleapis.com/token', {
         method: 'POST',
@@ -46,7 +46,8 @@ export function getOauthTokenGetter(settings: ServiceAccount) {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       });
       const { access_token, expires_in } = (await response.json()) as { access_token: string; expires_in: number };
-      tokens.set(scope, (token = access_token));
+      token = access_token;
+      tokens.set(scope, token);
       tokenExps.set(scope, now() + (expires_in || 0));
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,21 @@
 {
   "compilerOptions": {
-    "target": "es2021",
+    "target": "es2022",
+    "module": "esnext",
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
-    "lib": [
-      "es2021"
-    ],
+    "skipLibCheck": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": false,
+    "lib": ["es2022"],
     "resolveJsonModule": true,
-    "types": [
-      "@cloudflare/workers-types"
-    ]
+    "types": ["@cloudflare/workers-types"]
   },
   "include": ["src/**/*"],
   "exclude": ["src/__getToken.ts", "src/test.ts"]


### PR DESCRIPTION
## Summary
- Enable `strict` in tsconfig and modernize module/target so the published `.d.ts` files no longer leak loose types into consumer projects (the source of the red squiggles when other packages import this library).
- Add `prettier` devDep with `format`, `format:check`, and `typecheck` scripts; ran prettier across `src/`.
- Tighten the source to satisfy strict: nullability fixes across auth, firestore, service, tokens; declared symbol-keyed class fields; fixed serializer return types; corrected `doubleValue` to be a number per the API.

## Breaking type changes (minor bump to 0.3.0)
These match what the code already returned at runtime, but consumers may need to handle the new optional/nullable cases:
- `DocumentReference#create/set/update` → `Promise<Date | undefined>` (Firestore writes don't always include `updateTime`, e.g. transforms).
- `WriteBatch#commit` → `Array<Date | undefined>`.
- `SignInResponse.user` → `User | null`.
- `User.name` → optional.
- `DocumentSnapshot#createTime/updateTime/readTime` → `Date | undefined`.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` produces `dist/`
- [x] `npm run format:check` passes
- [ ] Smoke test in a downstream consumer project to confirm the red squiggles are gone